### PR TITLE
Feat 22 socket multiplayer

### DIFF
--- a/client/components/Ui.js
+++ b/client/components/Ui.js
@@ -18,7 +18,7 @@ class Ui extends React.Component {
             this.props.tileMap.map((tile, ind) => {
               if ((ind + 1) % this.props.rowLength === 0) {
                 return (
-                  <span key={ind} className={'tile' + tile}>
+                  <span key={ind} className={'tile tile' + tile}>
                     <span>
                       {this.props.shipInd === ind ? '❗️' : ' ' + tile + ' '}
                     </span>
@@ -27,7 +27,7 @@ class Ui extends React.Component {
                 );
               } else {
                 return (
-                  <span key={ind} className={'tile' + tile}>
+                  <span key={ind} className={'tile tile' + tile}>
                     {this.props.shipInd === ind ? '❗️' : ' ' + tile + ' '}
                   </span>
                 );

--- a/client/phaser/playScene.js
+++ b/client/phaser/playScene.js
@@ -3,6 +3,7 @@ import Phaser from 'phaser';
 import Ship from './ship';
 import getTileIndices from '../util/getTileIndices';
 import Opponent from './Opponent';
+import socket from '../socket';
 
 export default class PlayScene extends Phaser.Scene {
   constructor() {
@@ -89,6 +90,14 @@ export default class PlayScene extends Phaser.Scene {
     const {SHIFT} = Phaser.Input.Keyboard.KeyCodes;
     this.keys = this.input.keyboard.addKeys({
       shift: SHIFT
+    });
+    // **************************************************
+
+    // ***************** Set up Socket ******************
+
+    // Set up our socket listener for updates from the server
+    socket.on('updateState', (players, newTileMap, newTileMapRowLength) => {
+      this.onUpdateState(players, newTileMap, newTileMapRowLength);
     });
     // **************************************************
   }
@@ -238,5 +247,17 @@ export default class PlayScene extends Phaser.Scene {
       socketId: '',
       opponent: newOpponnent
     });
+  }
+  // this is called in our listeners file whenever
+  onUpdateState(players, newTileMap, newTileMapRowLength) {
+    // when we get updates from the server we need to update the tilemap in phaser...
+    this.foregroundLayer.putTilesAt(newTileMap, 0, 0);
+    // and in our store
+    clientStore.dispatch(
+      clientActionCreators.game.setTilemap(newTileMap, newTileMapRowLength)
+    );
+
+    // also update opponents
+    // TODO
   }
 }

--- a/client/phaser/playScene.js
+++ b/client/phaser/playScene.js
@@ -240,6 +240,7 @@ export default class PlayScene extends Phaser.Scene {
   }
 
   makeOpponent(x, y, direction) {
+    // TODO this is not implemented anywhere yet
     let newOpponnent = new Opponent(this, x, y, direction);
 
     // add the opponent to our list of opponents

--- a/client/phaser/playScene.js
+++ b/client/phaser/playScene.js
@@ -258,6 +258,12 @@ export default class PlayScene extends Phaser.Scene {
   // this is called in our listeners file whenever
   onUpdateState(players, newTileMap, newTileMapRowLength) {
     // when we get updates from the server we need to update the tilemap in phaser...
+    console.log(
+      'newTileMap',
+      newTileMap,
+      'newTileMap.length',
+      newTileMap.length
+    );
     this.foregroundLayer.putTilesAt(newTileMap, 0, 0);
     // and in our store
     clientStore.dispatch(

--- a/client/phaser/playScene.js
+++ b/client/phaser/playScene.js
@@ -4,6 +4,7 @@ import Ship from './ship';
 import * as TileMapJS from '../../public/assets/hopperio-tilemap.json';
 import getTileIndices from '../util/getTileIndices';
 import Opponent from './Opponent';
+import {IndToXY} from '../util/tileMapConversions';
 
 export default class PlayScene extends Phaser.Scene {
   constructor() {
@@ -32,15 +33,14 @@ export default class PlayScene extends Phaser.Scene {
   }
   init() {
     // used to prepare data
-
     // get the tilemap array data and send it to our clientStore
-    // now dont set it here, set it in listener from server
-    clientStore.dispatch(
-      clientActionCreators.game.setTilemap(
-        TileMapJS.layers[0].data,
-        TileMapJS.layers[0].width
-      )
-    );
+    // now dont set the tile map in store here, since its being set in the onStart listener with the tilemap from the server
+    // clientStore.dispatch(
+    //   clientActionCreators.game.setTilemap(
+    //     TileMapJS.layers[0].data,
+    //     TileMapJS.layers[0].width
+    //   )
+    // );
   }
   preload() {
     // loading in data
@@ -69,6 +69,10 @@ export default class PlayScene extends Phaser.Scene {
   create() {
     // adds objects to the game
 
+    // get the current state from store
+    // get the players location from store that was sent from the server
+    const {game: {playerWorldXY, tileMap}} = clientStore.getState();
+
     // **************** Set up the tilemap **************
 
     this.map = this.make.tilemap({
@@ -87,11 +91,19 @@ export default class PlayScene extends Phaser.Scene {
       this.foregroundLayer.height
     );
 
+    // set the tiles in phaser to match the store
+    // tileMap.present.forEach((tileIndex, ind) => {
+    //   let { x, y} = IndToXY(ind);
+
+    // })
+    // not sure if it'll take a flat array
+    this.foregroundLayer.putTilesAt(tileMap.present, 0, 0);
+
     // **************************************************
 
     // **************** Set up the Ship **************
 
-    this.createShip();
+    this.createShip(playerWorldXY);
 
     // **************************************************
 
@@ -105,14 +117,6 @@ export default class PlayScene extends Phaser.Scene {
       this.map.widthInPixels,
       this.map.heightInPixels
     );
-
-    // make sure camera cant leave the world
-    // this.cameras.main.setBounds(
-    //   0,
-    //   0,
-    //   this.map.widthInPixels,
-    //   this.map.heightInPixels
-    // );
 
     // **************************************************
 
@@ -181,10 +185,7 @@ export default class PlayScene extends Phaser.Scene {
     // introText.visible = true;
   }
 
-  createShip() {
-    // get the players location from store that was sent from the server
-    const {game: {playerWorldXY}} = clientStore.getState();
-
+  createShip(playerWorldXY) {
     console.log('playerWorldXY', playerWorldXY);
 
     this.ship = new Ship(
@@ -207,7 +208,6 @@ export default class PlayScene extends Phaser.Scene {
     // );
 
     // make the ship not able to leave the world
-    // for some reason adds weird borders in the middle of the map
     this.ship.sprite.body.setCollideWorldBounds(true);
   }
 

--- a/client/phaser/playScene.js
+++ b/client/phaser/playScene.js
@@ -34,6 +34,7 @@ export default class PlayScene extends Phaser.Scene {
     // used to prepare data
 
     // get the tilemap array data and send it to our clientStore
+    // now dont set it here, set it in listener from server
     clientStore.dispatch(
       clientActionCreators.game.setTilemap(
         TileMapJS.layers[0].data,

--- a/client/phaser/playScene.js
+++ b/client/phaser/playScene.js
@@ -1,10 +1,8 @@
 import clientStore, {clientActionCreators} from '../store';
 import Phaser from 'phaser';
 import Ship from './ship';
-import * as TileMapJS from '../../public/assets/hopperio-tilemap.json';
 import getTileIndices from '../util/getTileIndices';
 import Opponent from './Opponent';
-import {IndToXY} from '../util/tileMapConversions';
 
 export default class PlayScene extends Phaser.Scene {
   constructor() {
@@ -54,18 +52,6 @@ export default class PlayScene extends Phaser.Scene {
     this.load.image(this.TILE_SET_NAME, this.TILE_SET_PATH);
   }
 
-  randomizeXY(mapWidth, mapHeight, tileWidth, tileHeight) {
-    const maxX = mapWidth / tileWidth;
-    const maxY = mapHeight / tileHeight;
-    let startPosition = {};
-    //5 represents 3 as the min, so that the ship always spawns 3 tiles from the min border
-    //and 2 so that the ship always spawns 3 away from the max (its exclusive so its really -3 + 1)
-    //if we ever want to change the harbor size(right now were assuming 3x3) we would change these values!
-    startPosition.x = Math.floor(Math.random() * (maxX - 5) + 3) * tileWidth;
-    startPosition.y = Math.floor(Math.random() * (maxY - 5) + 3) * tileHeight;
-    return startPosition;
-  }
-
   create() {
     // adds objects to the game
 
@@ -75,29 +61,7 @@ export default class PlayScene extends Phaser.Scene {
 
     // **************** Set up the tilemap **************
 
-    this.map = this.make.tilemap({
-      key: 'map',
-      tileWidth: this.tileWidth,
-      tileHeight: this.tileHeight
-    });
-    const tileset = this.map.addTilesetImage(this.TILE_SET_NAME);
-
-    // might want to set up a static background layer
-    // this.backgroundLayer = this.map.createStaticLayer(0, tileset, 0, 0);
-    this.foregroundLayer = this.map.createDynamicLayer(0, tileset, 0, 0);
-
-    this.planeDimensions = this.map.worldToTileXY(
-      this.foregroundLayer.width,
-      this.foregroundLayer.height
-    );
-
-    // set the tiles in phaser to match the store
-    // tileMap.present.forEach((tileIndex, ind) => {
-    //   let { x, y} = IndToXY(ind);
-
-    // })
-    // not sure if it'll take a flat array
-    this.foregroundLayer.putTilesAt(tileMap.present, 0, 0);
+    this.createTileMap(tileMap);
 
     // **************************************************
 
@@ -209,6 +173,32 @@ export default class PlayScene extends Phaser.Scene {
 
     // make the ship not able to leave the world
     this.ship.sprite.body.setCollideWorldBounds(true);
+  }
+
+  createTileMap(tileMap) {
+    this.map = this.make.tilemap({
+      key: 'map',
+      tileWidth: this.tileWidth,
+      tileHeight: this.tileHeight
+    });
+    const tileset = this.map.addTilesetImage(this.TILE_SET_NAME);
+
+    // might want to set up a static background layer
+    // this.backgroundLayer = this.map.createStaticLayer(0, tileset, 0, 0);
+    this.foregroundLayer = this.map.createDynamicLayer(0, tileset, 0, 0);
+
+    this.planeDimensions = this.map.worldToTileXY(
+      this.foregroundLayer.width,
+      this.foregroundLayer.height
+    );
+
+    // set the tiles in phaser to match the store
+    // tileMap.present.forEach((tileIndex, ind) => {
+    //   let { x, y} = IndToXY(ind);
+
+    // })
+    // not sure if it'll take a flat array
+    this.foregroundLayer.putTilesAt(tileMap.present, 0, 0);
   }
 
   manuallyMakeHarbor() {

--- a/client/phaser/playScene.js
+++ b/client/phaser/playScene.js
@@ -21,9 +21,6 @@ export default class PlayScene extends Phaser.Scene {
 
     this.alive = true;
 
-    // the indicies for the different kinds of tiles
-    this.tileValues = getTileIndices();
-
     // this.shipSpawnX =
 
     // store the opponents
@@ -58,7 +55,16 @@ export default class PlayScene extends Phaser.Scene {
 
     // get the current state from store
     // get the players location from store that was sent from the server
-    const {game: {playerWorldXY, tileMap}} = clientStore.getState();
+    const {
+      game: {playerWorldXY, tileMap, pathIndex, harborIndex}
+    } = clientStore.getState();
+
+    // the indicies for the different kinds of tiles
+    this.tileValues = getTileIndices();
+
+    // the specific values for this player
+    this.harborIndex = harborIndex;
+    this.pathIndex = pathIndex;
 
     // **************** Set up the tilemap **************
 
@@ -229,8 +235,8 @@ export default class PlayScene extends Phaser.Scene {
 
       if (this.keys.shift.isDown) {
         this.ship.fillArea(clickedTile);
-      } else if (clickedTile.index !== this.tileValues.harbor) {
-        this.setTileIndex(this.tileValues.harbor, {
+      } else if (clickedTile.index !== this.harborIndex) {
+        this.setTileIndex(this.harborIndex, {
           type: 'world', //must indicate format of xy
           x: snappedWorldPoint.x,
           y: snappedWorldPoint.y

--- a/client/phaser/ship.js
+++ b/client/phaser/ship.js
@@ -176,10 +176,7 @@ export default class Ship {
           playerPhaserXY.present.y,
           currentTileIdx.previous
         ]);
-      } else if (
-        currentTileIdx.previous !== this.scene.tileValues.harbor &&
-        currentTileIdx.present === this.scene.tileValues.harbor
-      ) {
+      } else if (this.shouldSetEntryPoint(currentTileIdx, exitPoint)) {
         // If the user is moving from sea to harbor, then we must set the entry point
 
         clientStore.dispatch(
@@ -217,6 +214,16 @@ export default class Ship {
         );
       }
     }
+  }
+
+  shouldSetEntryPoint(currentTileIdx, exitPoint) {
+    // should set entry point if exitpoint has already been set and
+    // If the user is moving from sea to harbor
+    return (
+      exitPoint &&
+      currentTileIdx.previous !== this.scene.tileValues.harbor &&
+      currentTileIdx.present === this.scene.tileValues.harbor
+    );
   }
 
   isPath(currentTile) {

--- a/client/phaser/ship.js
+++ b/client/phaser/ship.js
@@ -1,7 +1,7 @@
 /* eslint-disable complexity */
 import Phaser from 'phaser';
 import clientStore, {clientActionCreators} from '../store';
-import {XYToInd} from '../util/tileMapConversions';
+import emitState from '../socket/emitState';
 
 export default class Ship {
   constructor(scene, x, y) {
@@ -116,6 +116,15 @@ export default class Ship {
     this.setPath(game);
 
     // *************************************************
+
+    // get the updated state and emit it to the server
+    // we want to tell the server everytime we move
+    // if this overloading the server then we may want to move it into the setPath if clause at the end
+    let {
+      game: {playerWorldXY, direction, tileMapDiff}
+    } = clientStore.getState();
+
+    emitState(playerWorldXY.present, direction.present, tileMapDiff);
   }
 
   // eslint-disable-next-line complexity

--- a/client/phaser/ship.js
+++ b/client/phaser/ship.js
@@ -16,8 +16,6 @@ export default class Ship {
 
     // ********* Set the Ship's starting location *********
 
-    let tileXY = this.scene.map.worldToTileXY(x, y);
-
     this.sprite = scene.physics.add
       .sprite(x, y, 'ship', 0)
       // .setDrag(1000, 0)
@@ -39,11 +37,6 @@ export default class Ship {
     //updating store with harbor
     clientStore.dispatch(
       clientActionCreators.game.setTiles(harbor, this.scene.tileValues.harbor)
-    );
-
-    //will need to remove this once getting location from the store from server
-    clientStore.dispatch(
-      clientActionCreators.game.setPlayerXY(tileXY.x, tileXY.y, this.facingDir)
     );
 
     // **************************************

--- a/client/phaser/ship.js
+++ b/client/phaser/ship.js
@@ -239,7 +239,8 @@ export default class Ship {
   }
 
   isPath(currentTile) {
-    if (currentTile.index === this.scene.pathIndex) {
+    // if the tile is any of the path tiles
+    if (this.scene.tileValues.path.includes(currentTile.index)) {
       return true;
     }
     return false;

--- a/client/socket/emitState.js
+++ b/client/socket/emitState.js
@@ -1,15 +1,12 @@
 import socket from './';
 
-function emitState(playerWorldX, playerWorldY, direction, tilemap) {
+function emitState(playerWorldXY, direction, tilemapDiff) {
   // the player should send not the whole tilemap, but a diff of what has changed in their tilemap.
-  // so maybe an array that has 0 value as what has stayed the same, and then a value for what the tile at that position has changed to
-  // maybe we can use a bitmask to show what has changed?
+  // tilemapDiff is an array of objects with the store tileMap ind and the tile index
   // here we want to emit to the server when our player moves and the new state of the player in update of our playScene
-  // so call this in the playScene or ship update
+  // so call this in the ship's setPath
 
-  // write a function to make the diff maybe not here
-  let tilemapDiff = [];
-  socket.emit('playerMove', playerWorldX, playerWorldY, direction, tilemapDiff);
+  socket.emit('playerMove', playerWorldXY, direction, tilemapDiff);
 }
 
 export default emitState;

--- a/client/socket/listeners.js
+++ b/client/socket/listeners.js
@@ -10,8 +10,8 @@ function initClientListeners(io, socket) {
   // console.log(tileMap.present);
 
   //
-  socket.on('startingInfo', (players, thisPlayer) =>
-    onStart(players, thisPlayer)
+  socket.on('startingInfo', (players, thisPlayer, tileMap, tileMapRowLength) =>
+    onStart(players, thisPlayer, tileMap, tileMapRowLength)
   );
 
   socket.on('newPlayer', player => onNewPlayer(player));
@@ -30,13 +30,19 @@ function onRemovedPlayer(removedPlayerID) {
   // TODO
 }
 
-async function onStart(players, thisPlayer) {
+async function onStart(players, thisPlayer, tileMap, tileMapRowLength) {
   // here we'll want to convert the players object into a list that is useable by phaser
   console.log('Here are the other players', players);
   // dispatch INIT_OPPONENTS in opponent reducer
   // TODO
 
   console.log('This is the new player, you!', thisPlayer);
+  console.log('tileMap', tileMap);
+  // set the client's tilemap
+  await clientStore.dispatch(
+    clientActionCreators.game.setTilemap(tileMap, tileMapRowLength)
+  );
+
   // set this players starting position in tile coords
   await clientStore.dispatch(
     clientActionCreators.game.setPlayerXY(

--- a/client/socket/listeners.js
+++ b/client/socket/listeners.js
@@ -43,6 +43,15 @@ async function onStart(players, thisPlayer, tileMap, tileMapRowLength) {
 
   console.log('This is the new player, you!', thisPlayer);
   console.log('tileMap', tileMap);
+
+  // set the path and tile values for the player
+  await clientStore.dispatch(
+    clientActionCreators.game.setTileValues(
+      thisPlayer.pathIndex,
+      thisPlayer.harborIndex
+    )
+  );
+
   // set the client's tilemap
   await clientStore.dispatch(
     clientActionCreators.game.setTilemap(tileMap, tileMapRowLength)

--- a/client/socket/listeners.js
+++ b/client/socket/listeners.js
@@ -20,6 +20,11 @@ function initClientListeners(io, socket) {
   socket.on('removedPlayer', removedPlayerID =>
     onRemovedPlayer(removedPlayerID)
   );
+
+  // The onUpdateState listener must be in playScene so that it can manipulate phaser objects
+  // socket.on('updateState', (players, newTileMap) => {
+  //   onUpdateState(players, newTileMap);
+  // });
 }
 
 function onRemovedPlayer(removedPlayerID) {
@@ -65,5 +70,11 @@ function onNewPlayer(player) {
   // dispath action addOpponent in opponet reducer
   // TODO
 }
+
+// function onUpdateState(players, newTileMap) {
+//   // when we get updates from the server we need to update the tilemap in our store and in phaser...
+//   // also update opponents
+//   // TODO
+// }
 
 export default initClientListeners;

--- a/client/store/game.js
+++ b/client/store/game.js
@@ -2,7 +2,8 @@
 /* eslint-disable no-case-declarations */
 // IndToXY returns obj {x,y}
 import {XYToInd, tileXYToWorldXY} from '../util/tileMapConversions';
-
+import getTileIndices from '../util/getTileIndices';
+let harborIndex = getTileIndices().harbor;
 /**
  * INITIAL STATE
  */
@@ -25,8 +26,8 @@ const initialState = {
     present: ''
   },
   currentTileIdx: {
-    previous: null,
-    present: null
+    previous: harborIndex,
+    present: harborIndex //initialize to harbor because player should always start on a harbor
   },
   entryPoint: null,
   exitPoint: null,
@@ -257,6 +258,7 @@ export default function gameReducer(state = initialState, action) {
             }
           })
         },
+        // only update if the tile the player is on is being changed
         currentTileIdx: {
           previous:
             ind === playerInd
@@ -286,13 +288,30 @@ export default function gameReducer(state = initialState, action) {
         // and also record the changes
         newChanges.push({tileInd: i, tileIndex: action.tileIndex});
       });
+      // check to see if a player is on a tile being changed
+      let playerOnTile = inds.includes(
+        XYToInd(
+          state.playerXY.present.x,
+          state.playerXY.present.y,
+          state.tileMapRowLength
+        )
+      );
       return {
         ...state,
         tileMap: {
           previous: [...state.tileMap.present],
           present: presentCopy
         },
-        tileMapDiff: newChanges
+        tileMapDiff: newChanges,
+        // only update if the tile the player is on is being changed
+        currentTileIdx: {
+          previous: playerOnTile
+            ? {...state.currentTileIdx}.present
+            : state.currentTileIdx.previous,
+          present: playerOnTile
+            ? action.tileIndex
+            : state.currentTileIdx.present
+        }
       };
     case CHANGE_PATH_TO_HARBOR:
       // make copy of tileMapDiff

--- a/client/store/game.js
+++ b/client/store/game.js
@@ -2,13 +2,14 @@
 /* eslint-disable no-case-declarations */
 // IndToXY returns obj {x,y}
 import {XYToInd, tileXYToWorldXY} from '../util/tileMapConversions';
-import getTileIndices from '../util/getTileIndices';
-let harborIndex = getTileIndices().harbor;
+
 /**
  * INITIAL STATE
  */
 
 const initialState = {
+  pathIndex: null, //get this from the server
+  harborIndex: null,
   playerWorldXY: {
     previous: {}, //in phaser order
     present: {}
@@ -26,8 +27,8 @@ const initialState = {
     present: ''
   },
   currentTileIdx: {
-    previous: harborIndex,
-    present: harborIndex //initialize to harbor because player should always start on a harbor
+    previous: null,
+    present: null //initialize to harbor because player should always start on a harbor
   },
   entryPoint: null,
   exitPoint: null,
@@ -53,6 +54,7 @@ const SET_TILEMAP = 'SET_TILEMAP';
 const SET_TILE = 'SET_TILE';
 const SET_TILES = 'SET_TILES';
 const CHANGE_PATH_TO_HARBOR = 'CHANGE_PATH_TO_HARBOR';
+const SET_TILE_VALUES = 'SET_TILE_VALUES';
 
 /**
  * ACTION CREATORS
@@ -104,10 +106,13 @@ export const gameActionCreators = {
     XYArray, //we must switch phaser x and y for javascript (see tileMapConversions.js for detailed explanation)
     tileIndex //the tile index aka the type of tile
   }),
-  changePathToHarbor: (pathTileIndex, harborTileIndex) => ({
-    type: CHANGE_PATH_TO_HARBOR,
-    pathTileIndex,
-    harborTileIndex
+  changePathToHarbor: () => ({
+    type: CHANGE_PATH_TO_HARBOR
+  }),
+  setTileValues: (pathIndex, harborIndex) => ({
+    type: SET_TILE_VALUES,
+    pathIndex,
+    harborIndex
   })
 };
 
@@ -319,11 +324,11 @@ export default function gameReducer(state = initialState, action) {
       // make copy of the current tilemap
       let newTileMap = [...state.tileMap.present];
       newTileMap.forEach((tileVal, i) => {
-        if (tileVal === action.pathTileIndex) {
+        if (tileVal === state.pathIndex) {
           // change the value from path to harbor
-          newTileMap[i] = action.harborTileIndex;
+          newTileMap[i] = state.harborIndex;
           // record the change
-          newTileMapDiff.push({tileInd: i, tileIndex: action.harborTileIndex});
+          newTileMapDiff.push({tileInd: i, tileIndex: state.harborIndex});
         }
       });
       return {
@@ -333,6 +338,12 @@ export default function gameReducer(state = initialState, action) {
           present: newTileMap
         },
         tileMapDiff: newTileMapDiff
+      };
+    case SET_TILE_VALUES:
+      return {
+        ...state,
+        pathIndex: action.pathIndex,
+        harborIndex: action.harborIndex
       };
     default:
       return state;

--- a/client/store/opponents.js
+++ b/client/store/opponents.js
@@ -17,7 +17,7 @@ const UPDATE_OPPONENTS_POS = 'UPDATE_OPPONENTS_POS';
  * ACTION CREATORS
  */
 export const opponentActionCreators = {
-  // when a new player joins this action will be dispatched to add them to the players store
+  // when a new player joins this action will be dispatched to add all other current players to the players store
   addOpponent: opponent => ({
     type: ADD_OPPONENT,
     opponent
@@ -50,11 +50,11 @@ export const opponentActionCreators = {
 export default function opponentReducer(state = initialState, action) {
   switch (action.type) {
     case INIT_OPPONENTS:
-      return [...state, action.opponents];
+      return [...state, ...action.opponents];
     case ADD_OPPONENT:
       return [...state, action.opponent];
     case UPDATE_OPPONENTS_POS:
-      return [...state, action.opponents];
+      return [...state, ...action.opponents];
     case REMOVE_OPPONENT:
       return state.filter(opponent => {
         return opponent.Id !== action.opponentId;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "seed": "node script/seed.js",
     "start": "node server",
     "start-dev": "NODE_ENV='development' npm run build-client-watch & NODE_ENV='development' npm run start-server",
-    "start-server": "nodemon server -e html,js,scss --ignore public --ignore client",
+    "start-server": "nodemon server ​—-inspect​​ -e html,js,scss --ignore public --ignore client",
     "test": "NODE_ENV='test' mocha \"./server/**/*.spec.js\" \"./client/**/*.spec.js\" \"./script/**/*.spec.js\" --require @babel/polyfill --require @babel/register"
   },
   "husky": {

--- a/public/assets/8colors50x50Tileset.tsx
+++ b/public/assets/8colors50x50Tileset.tsx
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <tileset version="1.2" tiledversion="1.2.4" name="8colors50x50Tileset" tilewidth="50" tileheight="50" tilecount="8" columns="2">
  <image source="tile-set50x50tiles.png" width="100" height="200"/>
- <tile id="0" type="opponentPath"/>
- <tile id="1" type="opponentHarbor"/>
- <tile id="2" type="opponentPath"/>
- <tile id="3" type="opponentHarbor"/>
+ <tile id="0" type="path"/>
+ <tile id="1" type="harbor"/>
+ <tile id="2" type="path"/>
+ <tile id="3" type="harbor"/>
  <tile id="4" type="regular"/>
  <tile id="5" type="harbor"/>
  <tile id="6" type="border">

--- a/public/assets/hopperio-tilemap.json
+++ b/public/assets/hopperio-tilemap.json
@@ -2537,19 +2537,19 @@
       "tiles": [
         {
           "id": 0,
-          "type": "opponentPath"
+          "type": "path"
         },
         {
           "id": 1,
-          "type": "opponentHarbor"
+          "type": "harbor"
         },
         {
           "id": 2,
-          "type": "opponentPath"
+          "type": "path"
         },
         {
           "id": 3,
-          "type": "opponentHarbor"
+          "type": "harbor"
         },
         {
           "id": 4,

--- a/public/assets/hopperio-tilemap.tmx
+++ b/public/assets/hopperio-tilemap.tmx
@@ -2,10 +2,10 @@
 <map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="50" height="50" tilewidth="50" tileheight="50" infinite="0" nextlayerid="2" nextobjectid="1">
  <tileset firstgid="1" name="8colors50x50Tileset" tilewidth="50" tileheight="50" tilecount="8" columns="2">
   <image source="tile-set50x50tiles.png" width="100" height="200"/>
-  <tile id="0" type="opponentPath"/>
-  <tile id="1" type="opponentHarbor"/>
-  <tile id="2" type="opponentPath"/>
-  <tile id="3" type="opponentHarbor"/>
+  <tile id="0" type="path"/>
+  <tile id="1" type="harbor"/>
+  <tile id="2" type="path"/>
+  <tile id="3" type="harbor"/>
   <tile id="4" type="regular"/>
   <tile id="5" type="harbor"/>
   <tile id="6" type="border">

--- a/public/style.css
+++ b/public/style.css
@@ -14,6 +14,7 @@ body {
   margin: 0;
   padding: 0;
   background-image: url('./assets/Galaxy-Photo.jpg');
+  background-size: cover;
 }
 
 a {
@@ -65,4 +66,5 @@ span.tile8 {
   margin-left: 40vw;
   margin-right: 40vw;
   border-radius: 15px;
+  min-width: 240px;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -36,21 +36,20 @@ form div {
 }
 
 /* Testing styles */
+span.tile {
+  padding: 0 5px;
+}
 span.tile5 {
   background-color: white;
-  padding: 0 5px;
 }
 span.tile6 {
   background-color: purple;
-  padding: 0 5px;
 }
 span.tile7 {
   background-color: rgb(49, 49, 49);
-  padding: 0 5px;
 }
 span.tile8 {
   background-color: pink;
-  padding: 0 5px;
 }
 
 .hopper-header {

--- a/server/db/models/Player.js
+++ b/server/db/models/Player.js
@@ -42,6 +42,15 @@ const Player = db.define('player', {
   isPlaying: {
     type: Sequelize.BOOLEAN,
     defaultValue: false
+  },
+  harborIndex: {
+    type: Sequelize.STRING
+  },
+  pathIndex: {
+    type: Sequelize.STRING
+  },
+  roomId: {
+    type: Sequelize.STRING
   }
 });
 

--- a/server/game/utils.js
+++ b/server/game/utils.js
@@ -1,8 +1,6 @@
 // get the map width and height from the tilemap
 const tileMap = require('../../public/assets/hopperio-tilemap.json');
 
-console.log('tileMap', tileMap);
-
 let [tileset] = tileMap.tilesets;
 let tileWidth = tileset.tilewidth;
 let tileHeight = tileset.tileheight;
@@ -121,11 +119,22 @@ function getTileIndices() {
   return tileValues;
 }
 
+function initTileMap(serverStore, serverActionCreators) {
+  // set the tilemap in the server store when the server starts up
+  serverStore.dispatch(
+    serverActionCreators.tiles.initTileMap(
+      tileMap.layers[0].data,
+      tileMap.layers[0].width
+    )
+  );
+}
+
 module.exports = {
   XYToInd,
   IndToXY,
   randomizeXY,
   worldXYToTileXY,
   tileXYToWorldXY,
-  getTileIndices
+  getTileIndices,
+  initTileMap
 };

--- a/server/index.js
+++ b/server/index.js
@@ -10,6 +10,8 @@ const sessionStore = new SequelizeStore({db});
 const PORT = process.env.PORT || 8080;
 const app = express();
 const socketio = require('socket.io');
+const {initTileMap} = require('./game/utils');
+const {serverStore, serverActionCreators} = require('./store');
 module.exports = app;
 
 // This is a global Mocha hook, used for resource cleanup.
@@ -108,6 +110,7 @@ const startListening = () => {
 const syncDb = () => db.sync({force: true});
 
 async function bootApp() {
+  await initTileMap(serverStore, serverActionCreators); //set the tilemap in server store
   await sessionStore.sync();
   await syncDb();
   await createApp();

--- a/server/socket/listeners.js
+++ b/server/socket/listeners.js
@@ -57,10 +57,7 @@ async function onPlayerStartGame(socket, socketId, name) {
   await serverStore.dispatch(playerStartGame(socket, socketId, name));
 
   // get all the players currently in the state
-  const {players} = serverStore.getState();
-
-  // also need to send them the current tilemap
-  // TODO
+  const {players, tiles} = serverStore.getState();
 
   // make a copy of players and remove the current player from the object so the player only gets their opponents
   // also make sure not sending any players not yet in the game
@@ -73,8 +70,22 @@ async function onPlayerStartGame(socket, socketId, name) {
     return player.socketId === socket.id;
   });
 
-  console.log('startingInfo', playersCopy, 'newPlayer', newPlayer);
-  socket.emit('startingInfo', playersCopy, newPlayer);
+  // also need to send them the current tilemap to the new player
+  console.log(
+    'startingInfo',
+    playersCopy,
+    'newPlayer',
+    newPlayer,
+    'tileMap',
+    tiles.tileMap
+  );
+  socket.emit(
+    'startingInfo',
+    playersCopy,
+    newPlayer,
+    tiles.tileMap.present,
+    tiles.tileMapRowLength
+  );
 
   // send the newPlayer to the other players
   console.log('newPlayer', newPlayer);

--- a/server/socket/listeners.js
+++ b/server/socket/listeners.js
@@ -62,7 +62,7 @@ async function onPlayerStartGame(socket, socketId, name) {
   await serverStore.dispatch(playerStartGame(socket, socketId, name));
 
   // get all the players currently in the state
-  const {players, tiles} = serverStore.getState();
+  const {players: {players}, tiles} = serverStore.getState();
 
   // make a copy of players and remove the current player from the object so the player only gets their opponents
   // also make sure not sending any players not yet in the game
@@ -111,7 +111,7 @@ async function onPlayerMove(socket, worldXY, direction, tilemapDiff) {
   await serverStore.dispatch(movePlayer(socket.id, worldXY, direction));
 
   // get the new state
-  const {players, tiles} = serverStore.getState();
+  const {players: {players}, tiles} = serverStore.getState();
 
   // make a copy of players and remove the current player from the object so the player only gets their opponents
   // also make sure not sending any players not yet in the game

--- a/server/socket/listeners.js
+++ b/server/socket/listeners.js
@@ -113,10 +113,16 @@ async function onPlayerMove(socket, worldXY, direction, tilemapDiff) {
   // get the new state
   const {players, tiles} = serverStore.getState();
 
+  // make a copy of players and remove the current player from the object so the player only gets their opponents
+  // also make sure not sending any players not yet in the game
+  const playersCopy = players.filter(player => {
+    return player.isPlaying && player.socketId !== socket.id;
+  });
+
   // and then broadcast the new state to all the other players
   socket.broadcast.emit(
     'updateState',
-    players,
+    playersCopy,
     tiles.tileMap.present,
     tiles.tileMapRowLength
   );

--- a/server/store/index.js
+++ b/server/store/index.js
@@ -8,7 +8,10 @@ const reducer = combineReducers({tiles: tilesReducer, players: playersReducer});
 
 const serverStore = createStore(
   reducer,
-  applyMiddleware(thunkMiddleware, createLogger({collapsed: true}))
+  applyMiddleware(
+    thunkMiddleware
+    // createLogger({collapsed: true})
+  )
 );
 
 const serverActionCreators = {

--- a/server/store/player.js
+++ b/server/store/player.js
@@ -1,5 +1,6 @@
 const {Player} = require('../db/models');
 const {randomizeXY, worldXYToTileXY} = require('../game/utils');
+console.log('require(../game/utils);', require('../game/utils.js'));
 /**
  * ACTION TYPES
  */
@@ -69,6 +70,7 @@ const playerStartGame = (socket, socketId, name) => {
       // update our player to be playing and the starting pos
       // Randomize spawn location
       let worldStartPos = randomizeXY();
+      console.log('type randomizeXY', typeof randomizeXY);
       let tileStartPos = worldXYToTileXY(worldStartPos.x, worldStartPos.y);
 
       const player = await Player.findOne({
@@ -89,30 +91,7 @@ const playerStartGame = (socket, socketId, name) => {
       });
 
       //and update in our store
-      dispatch(playersActionCreators.playerStartGame(player));
-      // get all the players currently in the state
-      const {players} = getState();
-
-      // also need to send them the current tilemap
-      // TODO
-
-      // make a copy of players and remove the current player from the object so the player only gets their opponents
-      // also make sure not sending any players not yet in the game
-      const playersCopy = players.filter(player => {
-        return player.isPlaying && player.socketId !== socket.id;
-      });
-
-      // get the new player
-      let newPlayer = players.find(player => {
-        return player.socketId === socket.id;
-      });
-
-      console.log('startingInfo', playersCopy, newPlayer);
-      socket.emit('startingInfo', playersCopy, newPlayer);
-
-      // send the newPlayer to the other players
-      console.log('newPlayer', newPlayer);
-      socket.broadcast.emit('newPlayer', newPlayer);
+      dispatch(playersActionCreators.playerStartGame(player.dataValues));
     } catch (error) {
       console.error(error);
     }

--- a/server/store/player.js
+++ b/server/store/player.js
@@ -1,5 +1,6 @@
 const {Player} = require('../db/models');
 const {randomizeXY, worldXYToTileXY} = require('../game/utils');
+const {getTileIndices} = require('../game/utils');
 /**
  * ACTION TYPES
  */
@@ -12,7 +13,9 @@ const MOVE_PLAYER = 'MOVE_PLAYER';
  * INITIAL STATE
  */
 
-const initialState = [];
+const initialState = {
+  players: []
+};
 
 /**
  * ACTION CREATORS
@@ -154,59 +157,71 @@ const movePlayer = (socketId, worldXY, direction) => {
 function playersReducer(state = initialState, action) {
   switch (action.type) {
     case ADDED_PLAYER:
-      return [
+      return {
         ...state,
-        {
-          socketId: action.player.socketId,
-          name: action.player.name,
-          phaserX: action.player.phaserX,
-          phaserY: action.player.phaserY,
-          worldX: action.player.worldX,
-          worldY: action.player.worldY,
-          x: action.player.x,
-          y: action.player.y,
-          isPlaying: action.player.isPlaying
-        }
-      ];
+        players: [
+          ...state.players,
+          {
+            socketId: action.player.socketId,
+            name: action.player.name,
+            phaserX: action.player.phaserX,
+            phaserY: action.player.phaserY,
+            worldX: action.player.worldX,
+            worldY: action.player.worldY,
+            x: action.player.x,
+            y: action.player.y,
+            isPlaying: action.player.isPlaying
+          }
+        ]
+      };
     case REMOVED_PLAYER:
-      return state.filter(player => {
-        return player.socketId !== action.socketId;
-      });
+      return {
+        ...state,
+        players: state.players.filter(player => {
+          return player.socketId !== action.socketId;
+        })
+      };
     case PLAYER_START_GAME:
       // update the player with new coords
-      return state.map(player => {
-        if (player.socketId === action.updatedPlayer.socketId) {
-          return {
-            ...player,
-            isPlaying: true,
-            phaserX: action.updatedPlayer.phaserX,
-            phaserY: action.updatedPlayer.phaserY,
-            worldX: action.updatedPlayer.worldX,
-            worldY: action.updatedPlayer.worldY,
-            x: action.updatedPlayer.x,
-            y: action.updatedPlayer.y
-          };
-        } else {
-          return player;
-        }
-      });
+      return {
+        ...state,
+        players: state.players.map(player => {
+          if (player.socketId === action.updatedPlayer.socketId) {
+            return {
+              ...player,
+              isPlaying: true,
+              phaserX: action.updatedPlayer.phaserX,
+              phaserY: action.updatedPlayer.phaserY,
+              worldX: action.updatedPlayer.worldX,
+              worldY: action.updatedPlayer.worldY,
+              x: action.updatedPlayer.x,
+              y: action.updatedPlayer.y
+            };
+          } else {
+            return player;
+          }
+        })
+      };
     case MOVE_PLAYER:
-      return state.map(player => {
-        if (player.socketId === action.updatedPlayer.socketId) {
-          return {
-            ...player,
-            phaserX: action.updatedPlayer.phaserX,
-            phaserY: action.updatedPlayer.phaserY,
-            worldX: action.updatedPlayer.worldX,
-            worldY: action.updatedPlayer.worldY,
-            x: action.updatedPlayer.x,
-            y: action.updatedPlayer.y,
-            direction: action.updatedPlayer.direction
-          };
-        } else {
-          return player;
-        }
-      });
+      return {
+        ...state,
+        players: state.players.map(player => {
+          if (player.socketId === action.updatedPlayer.socketId) {
+            return {
+              ...player,
+              phaserX: action.updatedPlayer.phaserX,
+              phaserY: action.updatedPlayer.phaserY,
+              worldX: action.updatedPlayer.worldX,
+              worldY: action.updatedPlayer.worldY,
+              x: action.updatedPlayer.x,
+              y: action.updatedPlayer.y,
+              direction: action.updatedPlayer.direction
+            };
+          } else {
+            return player;
+          }
+        })
+      };
     default:
       return state;
   }

--- a/server/store/tilesLocation.js
+++ b/server/store/tilesLocation.js
@@ -56,6 +56,7 @@ function tilesReducer(state = initialState, action) {
       action.tileMapDiff.forEach(({tileInd, tileIndex}) => {
         tileMapCopy[tileInd] = tileIndex;
       });
+
       return {
         ...state,
         tileMap: {

--- a/server/store/tilesLocation.js
+++ b/server/store/tilesLocation.js
@@ -20,7 +20,17 @@ const initialState = {
 /**
  * ACTION CREATORS
  */
-const tilesActionCreators = {};
+const tilesActionCreators = {
+  initTileMap: (tileMap, tileMapRowLength) => ({
+    type: INIT_TILEMAP,
+    tileMap,
+    tileMapRowLength
+  }),
+  updateTileMap: tileMapDiff => ({
+    type: UPDATE_TILEMAP,
+    tileMapDiff
+  })
+};
 /**
  * THUNK CREATORS
  */
@@ -30,6 +40,29 @@ const tilesActionCreators = {};
  */
 function tilesReducer(state = initialState, action) {
   switch (action.type) {
+    case INIT_TILEMAP:
+      return {
+        ...state,
+        tileMapRowLength: action.tileMapRowLength,
+        tileMap: {
+          previous: [...state.tileMap.present],
+          present: [...action.tileMap]
+        }
+      };
+    case UPDATE_TILEMAP:
+      // eslint-disable-next-line no-case-declarations
+      let tileMapCopy = [...state.tileMap.present];
+      // for all the reported changes from the client set them in our tilemap
+      action.tileMapDiff.forEach(({tileInd, tileIndex}) => {
+        tileMapCopy[tileInd] = tileIndex;
+      });
+      return {
+        ...state,
+        tileMap: {
+          previous: [...state.tileMap.present],
+          present: tileMapCopy
+        }
+      };
     default:
       return state;
   }


### PR DESCRIPTION
* changed how the tileValues property is structured so that all path and harbor tile are in arrays and each players own harbor and path tiles are assigned by the server and then set to properties on the scene.
     * when all the available path and harbor tiles have been assigned the isGameFull property on server store is set to true, but that value is not being utilized yet. It should probably change the view of the welcome screen to something else if isGameFull is true && isPlaying is false. (need to figure out how to get this as props on the client... maybe some kind of broadcast from the reducer + a isGameFull property in the GameState reducer on the client)
* players now emit to the server when they move to a new tile with their new position, direction, and any differences in the tilemap (called tileMapDiff in the store)
* when the server receives this event from the client it updates it's store and then broadcasts it to the other players as an updateState event
* When clients receive the updateState event the new tile map and positions are recorded in the store.
TODO
* the clients are not correctly setting the new tilemap they receive from the updateState event in phaser yet
* other players have not been hooked up as opponents in phaser yet
* when I try to see what happens with two players in the same browser it can get very slow, not sure what is causing this or what improvements can be made.
* when a player leaves or is killed their tiles need to be cleared from the tileMap
* most places where code needs to be filled in should be marked with TODO